### PR TITLE
Updated User & Routes for Spotify Auth

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -8,6 +8,7 @@ const UserSchema = new Schema({
   createdAt: { type: Date },
   updatedAt: { type: Date },
   spotifyToken: { type: String },
+  spotifyRefreshToken: { type: String },
   appleMusicToken: { type: String },
   active: {
     type: Boolean,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Sam Galizia <samgalizia@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "base-64": "^0.1.0",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.18.2",
     "dotenv": "^5.0.0",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -76,16 +76,7 @@ router.post('/login', (req, res) => {
           // Generate JWT token and return it
           let token = jwt.sign({ _id: user._id, email: user.email}, process.env.SECRET);
 
-          res.status(200).json({
-            status: 'Success',
-            messages: [
-              'User successfully logged in.'
-            ],
-            data: {
-              token: token,
-              user_id: user._id
-            }
-          });
+          clientResponse(res, 200, ['User successfully logged in.'], {token: token, user_id: user._id});
         }
         else {
           // Password did not match aka. Invalid Credentials.

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -4,6 +4,10 @@ const logger = require('../utils/logger');
 
 // Authentication Middleware
 function verifyAuth(req, res, next) {
+  // If it is a pre-flight CORS request, don't require Auth
+  if (req.method === 'OPTIONS') {
+    return next();
+  }
   // Get token from Authorization header
   // Header format - Authorization: Bearer [token]
   let authToken = req.get('Authorization').split(' ')[1];
@@ -42,7 +46,14 @@ function ignoreFavicon(req, res, next) {
 // Used to enable CORS
 function allowCORS(req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Headers','Origin, X-Requested-With, Content-Type, Accept');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE');
+  res.header('Access-Control-Allow-Headers','Origin, X-Requested-With, Content-Type, Accept, Authorization');
+
+  // If this is a preflight check, return okay with acceptable options
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(200);
+  }
+
   next();
 }
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,5 +1,7 @@
-const bodyParser = require('body-parser');
 const express = require('express');
+const bodyParser = require('body-parser');
+const rp = require('request-promise-native');
+const base64 = require('base-64');
 
 const {clientResponse} = require('../utils/client_response');
 const logger = require('../utils/logger');
@@ -49,7 +51,58 @@ router.put('/:id', (req, res) => {
     if (!user) { return clientResponse(res, 401); }
 
     // Everything worked, return the updated user
-    return clientResponse(res, 200, ['User updated successfully.'], user);
+    return clientResponse(res, 200, ['User updated successfully.']);
+  });
+});
+
+// POST /:id/spotifyAuth
+router.post('/:id/spotifyAuth', (req, res) => {
+  // If not authorized to make request, return 404
+  if (!isAuthorized(req)) {
+    return clientResponse(res, 404);
+  }
+
+  const code = req.body.code;
+  const redirect_uri = req.body.redirect_uri;
+  const auth = base64.encode(`${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`);
+
+  // Make request to spotify API
+  rp.post({
+    url: 'https://accounts.spotify.com/api/token',
+    form: {
+      grant_type: 'authorization_code',
+      code: code,
+      redirect_uri: redirect_uri
+    },
+    headers: {
+      'Authorization': `Basic ${auth}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    simple: false,
+    json: true, // automatically parses json response string
+    resolveWithFullResponse: false
+  }).then((json) => {
+    console.log(json);
+    let data = {
+      spotifyToken: json['access_token'],
+      spotifyRefreshToken: json['refresh_token']
+    };
+
+    User.findByIdAndUpdate(req.params.id, data, (err, user) => {
+      if (err) {
+        // Log error to console and return 400
+        logger.error(`Find User and Update Error: ${err}`);
+        return clientResponse(res, 400);
+      }
+
+      // No user exists with that id, return 401
+      if (!user) { return clientResponse(res, 401); }
+
+      // Everything worked, return the updated user
+      return clientResponse(res, 200, ['User updated successfully.']);
+    });
+  }).catch((err) => {
+    console.log(err);
   });
 });
 

--- a/test/routes/user.js
+++ b/test/routes/user.js
@@ -90,10 +90,6 @@ describe('User Routes', () => {
             res.body.should.have.property('status').eql('Success');
             res.body.should.have.property('messages');
             res.body.messages.should.contain('User updated successfully.');
-            res.body.should.have.property('data');
-            res.body.data.should.have.property('_id').eql(`${id}`);
-            res.body.data.should.have.property('spotifyToken').eql('spotify-token');
-            res.body.data.should.have.property('appleMusicToken').eql('apple-token');
             done(err);
           });
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,6 +215,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+
 base64-js@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"


### PR DESCRIPTION
Users can now send their auth code from Spotify to the API and it
will request a valid auth token and refresh token for the user and
on success store it in the DB.