### PR TITLE
Fixes #18 Token Refresh Issue

### DIFF
--- a/services/spotify.js
+++ b/services/spotify.js
@@ -24,7 +24,7 @@ function handleExpiredToken(wrapped) {
           .catch((err) => {
             // Custom error handling
             if (err.statusCode === 401) {
-              handleTokenRefresh(err, operation, args[1], reject);
+              return handleTokenRefresh(err, operation, args[0], reject);
             }
             reject(err);
           });
@@ -34,7 +34,6 @@ function handleExpiredToken(wrapped) {
 }
 
 function handleTokenRefresh(error, operation, user, reject) {
-  console.log('USER: ', user);
   // Attempt to refresh the auth token
   refreshAuthToken(user.spotifyRefreshToken)
     .then((json) => {
@@ -91,7 +90,7 @@ function refreshAuthToken(refresh_token) {
 }
 
 // Performs a search using search_term and returns results
-const search = handleExpiredToken(function(search_term, user) {
+const search = handleExpiredToken(function(user, search_term) {
   // Make the request to the API
   return rp.get({
     url: 'https://api.spotify.com/v1/search',


### PR DESCRIPTION
Upon closer inspection, the issue stemmed from the order of args in
the functions that were being wrapped. The search function had user
listed second, and the get playlists function only had one param, the
user. This caused issues because the placement of user in the args was
not consistent. THe solution is to make sure that user is always
first in the args list.