### PR TITLE
Hotfix: Build command not rebuilding frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "prepublishOnly": "cd sandpiper-frontend && yarn install && yarn build && cd ..",
+    "prepublish": "cd sandpiper-frontend && yarn install && yarn build && cd ..",
     "test": "nyc mocha --timeout 120000 --exit && yarn report",
     "remote_test": "nyc --reporter=lcovonly mocha --timeout 120000 --exit",
     "report": "nyc report --reporter=html",


### PR DESCRIPTION
Changing the build command `prepublish` to `prepublishOnly` fucked up the build sequence and was not regenerating the static build that is served from the root route. This has been fixed and tested live.