### PR TITLE
Fixed base_url to include staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "prepublish": "cd sandpiper-frontend && yarn install && yarn build && cd ..",
+    "heroku-postbuild": "cd sandpiper-frontend && yarn install && yarn build && cd ..",
     "test": "nyc mocha --timeout 120000 --exit && yarn report",
     "remote_test": "nyc --reporter=lcovonly mocha --timeout 120000 --exit",
     "report": "nyc report --reporter=html",

--- a/sandpiper-frontend/src/Utilities/networking.js
+++ b/sandpiper-frontend/src/Utilities/networking.js
@@ -1,10 +1,12 @@
 import rp from 'request-promise-native';
 
 var base_url = ''
-if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
-  base_url = 'http://staging.sandpiper.ninja/api';
-} else {
+if (process.env.NODE_ENV === 'production') {
   base_url = 'https://www.sandpiper.ninja/api';
+} else if (process.env.NODE_ENV === 'staging') {
+  base_url = 'http://staging.sandpiper.ninja/api';
+} else { // Not set or local development
+  base_url = 'localhost:3000/api';
 }
 
 function registerUser(data) {


### PR DESCRIPTION
This commit fixes and adds the staging environment to make sure that
the base url is pointing to the staging assets as intended. There is
also a tweak included that should fix when the frontend builds,
ensuring it only runs when we push to heorku.