### PR TITLE
Added Build Script for Frontend and Updated Travis YAML file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ deploy:
   app:
     develop: sandpiper-staging
     master: sandpiper-production
+  on:
+    repo: sgalizia/SandPiper

--- a/sandpiper-frontend/build.sh
+++ b/sandpiper-frontend/build.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+react-scripts build
+# Check if there is already a build folder
+# in the outer project. If so, remove it
+if [ -d ../public/build ]; then
+  rm -r ../public/build
+fi
+mv build ../public/build

--- a/sandpiper-frontend/package.json
+++ b/sandpiper-frontend/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && rm -r ../public/build && mv build ../public/build",
+    "build": "chmod +x ./build.sh && ./build.sh",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
The build script was required to prevent crashing when the build
folder does nto exist on the remote (or local when testing). It
will only attempt to remove the build folder if it exists.
The Travis file was updated to hopefully push to heroku on PR merge.